### PR TITLE
Fix kernel32dll reference to "kernel32.dll"

### DIFF
--- a/pageant_windows.go
+++ b/pageant_windows.go
@@ -66,7 +66,7 @@ var (
 	winFindWindow  = winAPI(user32dll, "FindWindowW")
 	winSendMessage = winAPI(user32dll, "SendMessageW")
 
-	kernel32dll           = windows.NewLazySystemDLL("user32.dll")
+	kernel32dll           = windows.NewLazySystemDLL("kernel32.dll")
 	winGetCurrentThreadID = winAPI(kernel32dll, "GetCurrentThreadId")
 )
 


### PR DESCRIPTION
The 'kernel32dll' variable points to 'user32.dll' instead of 'kernel32.dll', causing a panic when calling 'GetCurrentThreadId' method:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/50792403/191226252-94fe28fc-1fc0-44ab-bafe-b1059d8822d2.png">

The issue was found here:
https://github.com/jfrog/jfrog-cli/issues/1697