### PR TITLE
ssh and ssh-add on Windows can get keys from pipe

### DIFF
--- a/example/pageant_ssh.go
+++ b/example/pageant_ssh.go
@@ -1,0 +1,52 @@
+// based on [pageant](https://github.com/kbolino/pageant) of Kristian Bolino
+package main
+
+import (
+	"log"
+	"os"
+
+	sshagent "github.com/xanzy/ssh-agent"
+	"golang.org/x/crypto/ssh"
+)
+
+// This example requires all of the following to work:
+//   - environment variable PAGEANT_TEST_SSH_ADDR is set to a valid SSH
+//     server address (host:port)
+//   - environment variable PAGEANT_TEST_SSH_USER is set to a user name
+//     that the SSH server recognizes
+//   - Pageant is running on the local machine
+//   - Pageant has a key that is authorized for the user on the server
+func main() {
+	sshAgent, pageantConn, err := sshagent.New()
+	if err != nil {
+		log.Fatalf("error on New: %s", err)
+	}
+	defer pageantConn.Close()
+	keys, err := sshAgent.List()
+	if err != nil {
+		log.Fatalf("error on agent.List: %s", err)
+	}
+	if len(keys) == 0 {
+		log.Fatalf("no keys listed by Pagent")
+	}
+	for i, key := range keys {
+		log.Printf("key %d: %s %s\n", i, key.Comment, ssh.FingerprintSHA256(key))
+	}
+
+	signers, err := sshAgent.Signers()
+	if err != nil {
+		log.Fatalf("cannot obtain signers from SSH agent: %s", err)
+	}
+	sshUser := os.Getenv("PAGEANT_TEST_SSH_USER")
+	config := ssh.ClientConfig{
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signers...)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		User:            sshUser,
+	}
+	sshAddr := os.Getenv("PAGEANT_TEST_SSH_ADDR")
+	sshConn, err := ssh.Dial("tcp", sshAddr, &config)
+	if err != nil {
+		log.Fatalf("failed to connect to %s@%s due to error: %s", sshUser, sshAddr, err)
+	}
+	sshConn.Close()
+}

--- a/pageant_windows.go
+++ b/pageant_windows.go
@@ -36,7 +36,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Maximum size of message can be sent to pageant
+// Maximum size of message can be sent to pageant.
 const MaxMessageLen = 8192
 
 var (
@@ -76,8 +76,6 @@ func winAPI(dll *windows.LazyDLL, funcName string) func(...uintptr) (uintptr, ui
 }
 
 // Query sends message msg to Pageant and returns response or error.
-// 'msg' is raw agent request with length prefix
-// Response is raw agent response with length prefix
 func query(msg []byte) ([]byte, error) {
 	if len(msg) > MaxMessageLen {
 		return nil, ErrMessageTooLong

--- a/sshagent.go
+++ b/sshagent.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-// New returns a new agent.Agent that uses a unix socket
+// New returns a new agent.Agent that uses a unix socket.
 func New() (agent.Agent, net.Conn, error) {
 	if !Available() {
 		return nil, nil, errors.New("SSH agent requested but SSH_AUTH_SOCK not-specified")
@@ -44,7 +44,7 @@ func New() (agent.Agent, net.Conn, error) {
 	return agent.NewClient(conn), conn, nil
 }
 
-// Available returns true is a auth socket is defined
+// Available returns true if an auth socket is defined.
 func Available() bool {
 	return os.Getenv("SSH_AUTH_SOCK") != ""
 }

--- a/sshagent_windows_test.go
+++ b/sshagent_windows_test.go
@@ -1,0 +1,40 @@
+// based on [pageant](https://github.com/kbolino/pageant) of Kristian Bolino
+
+package sshagent
+
+import (
+	"testing"
+)
+
+// Pageant must be running for this test to work.
+func TestNew(t *testing.T) {
+	_, conn, err := New()
+	if err != nil {
+		t.Fatalf("error on New: %s", err)
+	} else if conn == nil {
+		t.Fatalf("New returned nil")
+	}
+	err = conn.Close()
+	if err != nil {
+		t.Fatalf("error on Conn.Close: %s", err)
+	}
+}
+
+// Pageant must be running and have at least 1 key loaded for this test to work.
+func TestSSHAgentList(t *testing.T) {
+	sshAgent, conn, err := New()
+	if err != nil {
+		t.Fatalf("error on New: %s", err)
+	}
+	defer conn.Close()
+	keys, err := sshAgent.List()
+	if err != nil {
+		t.Fatalf("error on agent.List: %s", err)
+	}
+	if len(keys) == 0 {
+		t.Fatalf("no keys listed by Pagent")
+	}
+	for i, key := range keys {
+		t.Logf("key %d: %s", i, key.Comment)
+	}
+}


### PR DESCRIPTION
not only from `\\.\pipe\openssh-ssh-agent` but by path in env "SSH_AUTH_SOCK"